### PR TITLE
Add custom resolution and multiple monitor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NoMoreBorder is a utility designed to enhance your multitasking experience by en
 
 Here's how NoMoreBorder looks in action, demonstrating its straightforward and user-friendly interface.
 
-![NoMoreBorder Interface](https://github.com/invcble/NoMoreBorder/blob/5e8ab8f751b4fd328d6e0698853f603cf4200e0a/pictures/NoMoreBorder.png)
+![Screenshot 2024-07-25 234700](https://github.com/user-attachments/assets/33682870-2d65-4683-bc57-794c06a8746c)
 
 ### Before and After
 
@@ -16,15 +16,21 @@ These screenshots demonstrate the effect of NoMoreBorder on a sample application
 
 #### Before Applying NoMoreBorder
 
-![Before NoMoreBorder](https://github.com/invcble/NoMoreBorder/blob/5e8ab8f751b4fd328d6e0698853f603cf4200e0a/pictures/From.png)
+![2024-07-25_23-53-30](https://github.com/user-attachments/assets/832e5ca1-2fde-45ca-8432-e85a9298f140)
 
 #### After Applying NoMoreBorder
 
-![After NoMoreBorder](https://github.com/invcble/NoMoreBorder/blob/5e8ab8f751b4fd328d6e0698853f603cf4200e0a/pictures/To.png)
+![FTLGame_2024-07-25_23-53-36](https://github.com/user-attachments/assets/cff48b76-fae0-4de8-846c-f48ff7a5b430)
+
+#### After Applying NoMoreBorder with custom resolution
+
+![2024-07-25_23-53-57](https://github.com/user-attachments/assets/b6051378-cd1d-4d05-a332-5d8503e393a8)
 
 ## Features
 
 - **Borderless Fullscreen**: Make any windowed application run in fullscreen mode without the traditional window borders, providing an immersive experience without altering the screen resolution.
+- **Custom Resolution**: Have a big screen and an old game made for small screens and low resolutions where windowed mode is too small but fullscreen is so big you barely read the dialog? Now you can also set a custom resolution.
+- **Multiple Monitor Support**: Ability to select which monitor you want the window to be on.
 - **Reversible Action**: Easily revert any changes made to the window, restoring the original windowed mode with borders.
 - **Session Memory**: NoMoreBorder remembers which applications were set to borderless mode, automatically reapplying these settings in future sessions. It's done through a configuration file, ensuring a seamless experience even after restarting the software or your computer.
 - **Dark Mode**: Includes a built-in dark mode, allowing for an on-the-fly theme switch to reduce eye strain during late-night sessions.
@@ -40,7 +46,7 @@ These screenshots demonstrate the effect of NoMoreBorder on a sample application
 You can run it as a python script or compile your own exe, I used pyinstaller. Ensure you have Python installed on your system along with the necessary packages: `customtkinter`, `pywin32`, and `pyinstaller`. These can be installed using pip:
 
 ```bash
-pip install customtkinter pywin32 pyinstaller
+pip install customtkinter pywin32 pyinstaller screeninfo
 ```
 
 ### Running NoMoreBorder

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ selected_monitor = None
 for index, m in enumerate(get_monitors()):
     # I'm not using m.name here because mine were really weird, like m.name='\\\\.\\DISPLAY17',
     # but there is probably a better way to do this
-    name = "Display " + str(index + 1)
+    name = f"Display {str(index + 1)}" 
     if(m.is_primary):
         name += " (Primary)"
         selected_monitor = name
@@ -219,12 +219,12 @@ window_list_dropdown.pack(padx=20, pady=(0, 10))
 monitor_frame = ctk.CTkFrame(panel, fg_color = "transparent")
 monitor_frame.pack(pady=10)
 
-resolution_dropdown = ctk.CTkComboBox(monitor_frame, values = list(resolution_options.keys()), width = 175, command = combo_answer_resolution)
-resolution_dropdown.grid(row=0, column=0, padx=(20, 5), pady=(0, 10))
-
 monitor_dropdown = ctk.CTkComboBox(monitor_frame, values = list(monitors.keys()), width = 175, command = combo_answer_display)
-monitor_dropdown.set(selected_monitor)
-monitor_dropdown.grid(row=0, column=1, padx=(5, 20), pady=(0, 10))
+monitor_dropdown.set(selected_monitor) # Main display isn't always Display 1, so set whatever the system default is
+monitor_dropdown.grid(row=0, column=0, padx=(20, 5), pady=(0, 10))
+
+resolution_dropdown = ctk.CTkComboBox(monitor_frame, values = list(resolution_options.keys()), width = 175, command = combo_answer_resolution)
+resolution_dropdown.grid(row=0, column=1, padx=(5, 20), pady=(0, 10))
 
 buttons_frame = ctk.CTkFrame(panel, fg_color = "transparent")
 buttons_frame.pack(pady=10)

--- a/main.py
+++ b/main.py
@@ -77,8 +77,12 @@ def refresh_window_list():
 def load_settings():
     try:
         with open("settings.json", "r") as f:
-            return json.load(f)
-    # TODO: Catch json existing but with wrong format? [] instead of {}
+            settings = json.load(f)
+            #  Upgrade to new settings format if "apps" is saved as a list
+            if isinstance(settings["apps"], list):
+                settings["apps"] = {app:(screen_width, screen_height) for app in settings["apps"]}
+                save_settings(settings)
+            return settings
     except:
         return {"theme": "System", "apps": {}}
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,28 @@ selected_app = "0"
 temp_win_height = 1080
 temp_win_width = 1920
 
+resolition_options = {
+    "Use Display Resolution": (screen_width, screen_height),
+    "3840x2160": (3840, 2160),
+    "3440x1440": (3440, 1440),
+    "2560x1600": (2560, 1600),
+    "2560x1440": (2560, 1440),
+    "2560x1600": (2560, 1600),
+    "2560x1080": (2560, 1080),
+    "1920x1200": (1920, 1200),
+    "1920x1080": (1920, 1080),
+    "1680x1050": (1680, 1050),
+    "1600x900": (1600, 900),
+    "1440x900": (1440, 900),
+    "1366x768": (1366, 768),
+    "1280x720": (1280, 720),
+    "1280x1024": (1280, 1024),
+    "1024x768": (1024, 768),
+    "800x600": (800, 600),
+    "640x480": (640, 480),
+}
+selected_resolution = resolition_options["Use Display Resolution"]
+
 def enum_window_proc(hwnd, resultList):
     if win32gui.IsWindowVisible(hwnd) and win32gui.GetWindowText(hwnd):
         resultList.append((hwnd, win32gui.GetWindowText(hwnd)))
@@ -85,6 +107,10 @@ def combo_answer(choice):
     global selected_app 
     selected_app = choice
 
+def combo_answer_resolution(choice):
+    global selected_resolution 
+    selected_resolution = resolition_options[choice]
+
 def make_borderless(check = None):
     global selected_app, windowList, saveList, temp_win_height, temp_win_width
     
@@ -107,8 +133,12 @@ def make_borderless(check = None):
     style 
     win32gui.SetWindowLong(hwnd, win32con.GWL_STYLE, style)
 
-    win32gui.MoveWindow(hwnd, 0, 0, screen_width, screen_height, True)
-    win32gui.SetWindowPos(hwnd, None, 0, 0, screen_width, screen_height, win32con.SWP_NOZORDER | win32con.SWP_FRAMECHANGED)
+    # Center on screen
+    location_x = screen_width//2 - (selected_resolution[0]//2)
+    location_y = screen_height//2 - (selected_resolution[1]//2)
+
+    win32gui.MoveWindow(hwnd, location_x, location_y, selected_resolution[0], selected_resolution[1], True)
+    win32gui.SetWindowPos(hwnd, None, location_x, location_y, selected_resolution[0], selected_resolution[1], win32con.SWP_NOZORDER | win32con.SWP_FRAMECHANGED)
 
     if selected_app not in saveList:
         saveList.append(selected_app)
@@ -141,7 +171,7 @@ ctk.set_appearance_mode(current_settings["theme"])
 ctk.set_default_color_theme("blue")  # Themes: "blue" / "green" / "dark-blue"
 
 panel = ctk.CTk()
-panel.geometry("400x270+"+ str(int(screen_width/2) - 200) + '+' + str(int(screen_height/2) - 200))
+panel.geometry("400x300+"+ str(int(screen_width/2) - 200) + '+' + str(int(screen_height/2) - 200))
 panel.resizable(False, False)
 panel.title('NoMoreBorder')
 
@@ -151,6 +181,9 @@ label.pack(pady=20)
 
 window_list_dropdown = ctk.CTkComboBox(panel, values = ["Select Application"], width = 400, command = combo_answer)
 window_list_dropdown.pack(padx=20, pady=(0, 10))
+
+resolution_dropdown = ctk.CTkComboBox(panel, values = list(resolition_options.keys()), width = 400, command = combo_answer_resolution)
+resolution_dropdown.pack(padx=20, pady=(0, 10))
 
 buttons_frame = ctk.CTkFrame(panel, fg_color = "transparent")
 buttons_frame.pack(pady=10)

--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,4 @@
 {
     "theme": "System",
-    "apps": []
+    "apps": {}
 }


### PR DESCRIPTION
I was using this to play FTL but ran into an issue with the game that's designed to be 720p not being a great experience to play in full screen on my 32 inch 4k monitor since the game was designed for smaller screens. All dialog and text would span the full 32 inches and would be impossible to read. So I decided to add support for picking what resolution you want the window to be, so I could select a resolution that's somewhere between "too small" and "too big".

This is my first time writing Python in years so feel free to point out anything weird.

I also added support for multiple monitors while I was at it. This aims to address #2 and I'm not sure I fully understood #1 but this might be an improvement for that issue too. I believe more can be done to allow truly custom inputs for exact resolutions and positions but I honestly found working with CTK Entry boxes to be annoying. If anyone else wants to extend this, feel free.

This changes how settings are saved and the "apps" list is now a dict. Functionality has been added to `load_settings` to support and update old settings to the new type, but this has not been tested extensively. Another point is that I'm not sure how consistent it is to use "Display 1" as a key in that dict, I'm not entirely sure what happens when screens are plugged in or out. 

Also, note that the [screeninfo](https://pypi.org/project/screeninfo/) package is now required to compile the app.

PS. Great little app! I've been getting a lot of use out of it for old games.